### PR TITLE
Make the copy of the O365 template explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,10 +260,14 @@ Install git if not already available:
 sudo apt -y install git
 ```
 
-Clone this repo:
+Clone this repo and copy the O365 phishlet:
 
 ```
 git clone https://github.com/waelmas/frameless-bitb
+```
+
+```
+cp -r /home/evilginx/frameless-bitb/O365.yaml /home/evilginx/evilginx/phishlets
 ```
 
 ```


### PR DESCRIPTION
Hi!

Thank you for your amazing work.

Following this, I just had some issues copying old o365 templates - until I realized you integrated the right™️ template directly in the repo, but it's missing for the README.

This should add an extra step in the README to copy the template.

Cheers!